### PR TITLE
memray 1.19.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "memray" %}
-{% set version = "1.19.1" %}
+{% set version = "1.19.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7fcf306eae2c00144920b01913f42fa7f235af7a80fa3226ab124672a5cb1d8f
+  sha256: 4e0fb29ff0a50c0ec9dc84294d8f2c83419feba561a37628b304c2ae4fe73d03
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.19.3" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -73,3 +73,7 @@ about:
 extra:
   recipe-maintainers:
     - matthiasdiener
+  skip-lints:
+    # elfutils is exactly pinned through the global
+    # conda_build_config.yaml, which the linter does not resolve here.
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
memray 1.19.3 

**Destination channel:** Defaults

### Links

- [PKG-16458]
- dev_url:        https://github.com/bloomberg/memray/tree/v1.19.3
- conda_forge:    https://github.com/conda-forge/memray-feedstock
- pypi:           https://pypi.org/project/memray/1.19.3
- pypi inspector: https://inspector.pypi.io/project/memray/1.19.3

### Explanation of changes:

- bump patch version
- suppress false-positive linter [errors and warnings](https://package-build.anaconda.com/v1/graph/458bbd08-4a66-43b8-a25a-886cda855293)


[PKG-16458]: https://anaconda.atlassian.net/browse/PKG-16458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ